### PR TITLE
fix statement about nil being seqable and sequence

### DIFF
--- a/src/language-basics.adoc
+++ b/src/language-basics.adoc
@@ -1123,7 +1123,7 @@ the emptiness of a sequence in ClojureScript which is often referred to as nil-p
 ;; => nil
 ----
 
-`nil` is also both a seqable and a sequence, and thus it supports all the functions we saw so far:
+Though `nil` is neither a seqable nor a sequence, it is supported by all the functions we saw so far:
 
 [source, clojure]
 ----


### PR DESCRIPTION
I found this line interesting!

> `nil` is also both a seqable and a sequence...

but I saw this in a following section:

```clj
(seq? nil)
;; => false
(seqable? nil)
;; => false
```

submitting a correction to the first statement for consistency.