### PR TITLE
reword potentially confusing comparison of maps and vectors

### DIFF
--- a/src/language-basics.adoc
+++ b/src/language-basics.adoc
@@ -1495,7 +1495,7 @@ faster than building a vector from a lazy sequence and making your intent more e
 
 ===== Maps
 
-Maps are ubiquitous in ClojureScript. Like vectors, they are also used as a syntactic construct for attaching metadata to
+Maps are ubiquitous in ClojureScript. Like vectors, they are also used as a syntactic construct, particularly for attaching metadata to
 vars. Any ClojureScript data structure can be used as a key in a map, although it's common to use keywords since they can
 also be called as functions.
 


### PR DESCRIPTION
> Like vectors, they are also used as a syntactic construct for attaching metadata to vars.

it sounded like vectors could be used to attach metadata to vars.  proposing a correction