### PR TITLE
correct default namespace to be cljs.user

### DIFF
--- a/src/language-basics.adoc
+++ b/src/language-basics.adoc
@@ -1997,13 +1997,13 @@ per file. Naturally, a namespace definition is usually at the beginning of the f
 docstring.
 
 Previously we have explained vars and symbols. Every var that you define will be associated
-with its namespace. If you do not define a concrete namespace, then the default one called "user" will be
+with its namespace. If you do not define a concrete namespace, then the default one called "cljs.user" will be
 used:
 
 [source, clojure]
 ----
 (def x "hello")
-;; => #'user/x
+;; => #'cljs.user/x
 ----
 
 


### PR DESCRIPTION
ClojureScript's default namespace is `cljs.user`.  [source](https://github.com/clojure/clojurescript/blob/r1.7.28/src/main/clojure/cljs/analyzer.cljc#L2673)