### PR TITLE
add 'property access shorthand' to interop section

### DIFF
--- a/src/language-basics.adoc
+++ b/src/language-basics.adoc
@@ -2816,6 +2816,29 @@ instead of using the `.` you use `.-`. Let's see an example:
 ;; => 3.141592653589793
 ----
 
+===== Property access shorthand
+
+Symbols with the `js/` prefix can contain dots to denote nested property access.
+Both of the following expressions invoke the same function:
+
+[source, clojure]
+----
+(.log js/console "Hello World")
+
+(js/console.log "Hello World")
+----
+
+And both of the following expressions access the same property:
+
+[source, clojure]
+----
+(.-PI js/Math)
+;; => 3.141592653589793
+
+js/Math.PI
+;; => 3.141592653589793
+----
+
 
 ===== JavaScript objects
 


### PR DESCRIPTION
This is a convenient, undocumented feature; one implemented accidentally:

<img width="749" alt="screen shot 2015-08-02 at 5 03 38 pm" src="https://cloud.githubusercontent.com/assets/116838/9028262/ae6db3f0-3938-11e5-8e27-db84349ef9cd.png">
