### PR TITLE
add `specify!` to Protocols section

### DIFF
--- a/src/language-basics.adoc
+++ b/src/language-basics.adoc
@@ -2720,6 +2720,44 @@ This is how we can emulate an instance of the user type that plays well with the
 ;; => "Yennefer of Vengerberg"
 ----
 
+==== Specify
+
+`specify!` is an advanced alternative to `reify`, allowing you to add protocol
+implementations to an existing JavaScript object.  This can be useful if
+you want to graft protocols onto a JavaScript library's components.
+
+[source, clojure]
+----
+(def obj #js {})
+
+(specify! obj
+  IUser
+  (full-name [_]
+    "my full name"))
+
+(full-name obj)
+;; => "my full name"
+----
+
+`specify` is an immutable version of `specify!` that can be used on immutable,
+copyable values implementing `ICloneable` (e.g. ClojureScript collections).
+
+[source, clojure]
+----
+(def a {})
+
+(def b (specify a
+         IUser
+         (full-name [_]
+           "my full name")))
+
+(full-name a)
+;; Error: No protocol method IUser.full-name defined for type cljs.core/PersistentArrayMap: {}
+
+(full-name b)
+;; => "my full name"
+----
+
 
 === Host interoperability
 


### PR DESCRIPTION
This is something unique to ClojureScript that is not in Clojure.

Om uses `specify!` to graft protocols onto React components ([source](https://github.com/omcljs/om/blob/0.9.0/src/om/core.cljs#L406-L436)).  It's really only for advanced interop, but maybe good to have right before the interop section.