### PR TITLE
clarify reason for applying aget/aset to objects

### DIFF
--- a/src/language-basics.adoc
+++ b/src/language-basics.adoc
@@ -2952,7 +2952,7 @@ Or access in an indexed way to get its values:
 ;; => 2
 ----
 
-In JavaScript, objects are also arrays, so you can use the same functions for interacting
+In JavaScript, array index access is equivalent to object property access, so you can use the same functions for interacting
 with plain objects:
 
 [source, clojure]


### PR DESCRIPTION
> In JavaScript, objects are also arrays ...

Just a pedantic correction since objects are not arrays