### PR TITLE
Doc: Update code snippet in 6.2.1 Channels

### DIFF
--- a/src/appendix.adoc
+++ b/src/appendix.adoc
@@ -358,7 +358,7 @@ closed. Because of that, putting a `nil` value on a channel is not allowed:
 
 (def ch (chan))
 
-(put! ch 42)
+(put! ch nil)
 ;; Error: Assert failed: Can't put nil in on a channel
 ----
 


### PR DESCRIPTION
Example error resulting from attempting to put `nil` on a channel was
using integer 42