### PR TITLE
This revision fixes a typo in file path.

### DIFF
--- a/src/compiler.adoc
+++ b/src/compiler.adoc
@@ -722,7 +722,7 @@ Open the `index.html` file and add the following content at the beginning of bod
 ----
 
 And the next step is adding some code to make the form interactive. Put the following
-code into the `src/leapyear/core.cljs`:
+code into the `src/leapyears/core.cljs`:
 
 [source, clojure]
 ----


### PR DESCRIPTION
The path mentioned in section `4.4.2. First project` references the path

    src/leapyear/core.cljs

This is not correct as the project was earlier created as

    lein new mies leapyears

So the path to core.cljs should be

    src/leapyears/core.cljs