### PR TITLE
Fix example function call to match the one defined in above example

### DIFF
--- a/src/compiler.adoc
+++ b/src/compiler.adoc
@@ -879,7 +879,7 @@ Now, open the repl, require the namespace and try to use the exposed function:
 [source, clojure]
 ----
 (require '[myextmods.myclosuremodule :as cm])
-(cm/getGreetings)
+(cm/get_greetings)
 ;; => "Hello from google closure module."
 ----
 


### PR DESCRIPTION
Or should it be fixed other way around or both should be `getGreetings`?