### PR TITLE
source-map is not accepted as a filename with optimizations :none

### DIFF
--- a/src/compiler.adoc
+++ b/src/compiler.adoc
@@ -221,7 +221,7 @@ _mywebapp/build.clj_ file with the following content:
 (b/build "src"
  {:output-to "main.js"
   :output-dir "out/"
-  :source-map "main.js.map"
+  :source-map true
   :main 'mywebapp.core
   :verbose true
   :optimizations :none})


### PR DESCRIPTION
The text as-is isn't accepted by the clojurescript build function. It produces this error message:
```
Caused by: java.lang.AssertionError: Assert failed: :source-map must be true or false when compiling with :optimizations :none but it is: "main.js.map"
(util/boolean? source-map)
```