### PR TITLE
Watch process had invalid source-map setting

### DIFF
--- a/src/compiler.adoc
+++ b/src/compiler.adoc
@@ -295,7 +295,7 @@ Start by creating another build script, but this time name it _watch.clj_:
 (b/watch "src"
  {:output-to "main.js"
   :output-dir "out/"
-  :source-map "main.js.map"
+  :source-map true
   :main 'mywebapp.core
   :optimizations :none})
 ----

--- a/src/compiler.adoc
+++ b/src/compiler.adoc
@@ -510,7 +510,7 @@ Let’s start by creating a file named `brepl.clj` with the following content:
 (b/build "src"
  {:output-to "main.js"
   :output-dir "out/"
-  :source-map "main.js.map"
+  :source-map true
   :main 'myapp.core
   :verbose true
   :optimizations :none})


### PR DESCRIPTION
As far as I can tell source-map <location> is only needed when optimizations is not none, so I'm guessing this is a typo. It fails for me if I don't set it to ``true``.