### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ git:
 	git submodule update
 
 docbook: setup
-	asciidoctor -b docbook45 -a numbered -d book -a data-uri!  src/index.adoc -o dist/clojurescript-unraveled.xml
+	asciidoctor -b docbook -a numbered -d book -a data-uri!  src/index.adoc -o dist/clojurescript-unraveled.xml
 
 pdf: docbook
 	./asciidoctor-fopub/fopub -t docbook-xsl dist/clojurescript-unraveled.xml


### PR DESCRIPTION
I tried to make a pdf using the Makefile on macOS.  It seems docbook had been upgraded to 5.0 in  homebrew. We need to change `docbook45` to `docbook` to follow the change.